### PR TITLE
Improve settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Setup
 ------
 
 * Edit `settings.yaml` to set paths for saving files.
+  * Begin with `/` stands for abosolute path.
+  * Begin without `/` or begin with `./` stands for absolute path from DEEPstation's `main.py`. 
 * Setup database. Try command below on root directory of DEEPstation.  
 `sqlite3 deepstation.db < ./scheme/deepstation.sql`
 * Startup server. `python main.py`
@@ -135,6 +137,8 @@ Setup
 ------
 
 * 各種ファイルの保存場所を`settings.yaml`に定義します。
+  * `/` で始まるパスは絶対パスとして処理されます。
+  * `/` で始まらないパス、`./`で始まるパスはDEEPstationの`main.py`が配置されているディレクトリ直下の相対パスとして処理されます。
 * データベースのセットアップを行います。DEEPstationをダウンロードしたディレクトリで下記のコマンドを実行してください。  
 `sqlite3 deepstation.db < ./scheme/deepstation.sql`
 * サーバを起動します。DEEPstationをダウンロードしたディレクトリで `python main.py`を実行します

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ import subprocess
 import chainer
 from xml.etree.ElementTree import *
 import six
-import six.moves.cPickle as pickle
+import cPickle as pickle
 from datetime import datetime
 from json import dumps
 from PIL import Image
@@ -41,13 +41,15 @@ app = bottle.Bottle()
 plugin = sqlite.Plugin(dbfile=DEEPSTATION_ROOT + os.sep + 'deepstation.db' )
 app.install(plugin)
 
-UPLOADED_IMAGES_DIR    = settings['uploaded_images']
-UPLOADED_RAW_FILES_DIR = settings['uploaded_raw_files']
-PREPARED_DATA_DIR      = settings['prepared_data']
-TRAINED_DATA_DIR       = settings['trained_data']
-TEMP_IMAGE_DIR         = settings['inspection_temp_image']
-INSPECTION_RAW_IMAGE   = settings['inspection_raw_image']
+UPLOADED_IMAGES_DIR    = DEEPSTATION_ROOT  + settings['uploaded_images']
+UPLOADED_RAW_FILES_DIR = DEEPSTATION_ROOT  + settings['uploaded_raw_files']
+PREPARED_DATA_DIR      = DEEPSTATION_ROOT  + settings['prepared_data']
+TRAINED_DATA_DIR       = DEEPSTATION_ROOT  + settings['trained_data']
+TEMP_IMAGE_DIR         = DEEPSTATION_ROOT  + settings['inspection_temp_image']
+INSPECTION_RAW_IMAGE   = DEEPSTATION_ROOT  + settings['inspection_raw_image']
 NVIDIA_SMI_CMD         = settings['nvidia_smi']
+
+
 
 # static files
 @app.route('/statics/<filepath:path>')

--- a/main.py
+++ b/main.py
@@ -40,16 +40,13 @@ f.close()
 app = bottle.Bottle()
 plugin = sqlite.Plugin(dbfile=DEEPSTATION_ROOT + os.sep + 'deepstation.db' )
 app.install(plugin)
-
-UPLOADED_IMAGES_DIR    = DEEPSTATION_ROOT  + settings['uploaded_images']
-UPLOADED_RAW_FILES_DIR = DEEPSTATION_ROOT  + settings['uploaded_raw_files']
-PREPARED_DATA_DIR      = DEEPSTATION_ROOT  + settings['prepared_data']
-TRAINED_DATA_DIR       = DEEPSTATION_ROOT  + settings['trained_data']
-TEMP_IMAGE_DIR         = DEEPSTATION_ROOT  + settings['inspection_temp_image']
-INSPECTION_RAW_IMAGE   = DEEPSTATION_ROOT  + settings['inspection_raw_image']
+UPLOADED_IMAGES_DIR = settings['uploaded_images'] if settings['uploaded_images'].startswith('/') else os.path.realpath(DEEPSTATION_ROOT + settings['uploaded_images'])
+UPLOADED_RAW_FILES_DIR = settings['uploaded_raw_files'] if settings['uploaded_raw_files'].startswith('/') else os.path.realpath(DEEPSTATION_ROOT + settings['uploaded_raw_files'])
+PREPARED_DATA_DIR      = settings['prepared_data'] if settings['prepared_data'].startswith('/') else os.path.realpath(DEEPSTATION_ROOT + settings['prepared_data'])
+TRAINED_DATA_DIR       = settings['trained_data'] if settings['trained_data'].startswith('/') else os.path.realpath(DEEPSTATION_ROOT + settings['trained_data'])
+TEMP_IMAGE_DIR         = settings['inspection_temp_image'] if settings['inspection_temp_image'].startswith('/') else os.path.realpath(DEEPSTATION_ROOT + settings['inspection_temp_image'])
+INSPECTION_RAW_IMAGE   = settings['inspection_raw_image'] if settings['inspection_raw_image'].startswith('/') else os.path.realpath(DEEPSTATION_ROOT + settings['inspection_raw_image'])
 NVIDIA_SMI_CMD         = settings['nvidia_smi']
-
-
 
 # static files
 @app.route('/statics/<filepath:path>')

--- a/main.py
+++ b/main.py
@@ -84,7 +84,7 @@ def index(db):
     datasets = []
     for d in dataset_rows:
         datasets.append({"id": d[0], "name": d[1], "dataset_path": d[2], "thumbnails": get_files_in_random_order(d[2], 4), "file_num": count_files(d[2]), "category_num": count_categories(d[2])})
-    return bottle.template('index.html', models = models.fetchall(), datasets = datasets, gpu_info = get_gpu_info(), chainer_version = get_chainer_version(), python_version = get_python_version())
+    return bottle.template('index.html', models = models.fetchall(), datasets = datasets, system_info = get_system_info(), gpu_info = get_gpu_info(), chainer_version = get_chainer_version(), python_version = get_python_version())
 
 @app.route('/inspection/upload', method='POST')
 def do_upload_for_inspection(db):
@@ -214,7 +214,7 @@ def show_model_detail(id, db):
     model_txt = open(ret['network_path']).read()
     row_all_datasets = db.execute('select id, name from Dataset')
     all_datasets_info = row_all_datasets.fetchall()
-    return bottle.template('models_detail.html', model_info = ret, datasets = all_datasets_info, model_txt=model_txt,gpu_info = get_gpu_info(), chainer_version = get_chainer_version(), python_version = get_python_version())
+    return bottle.template('models_detail.html', model_info = ret, datasets = all_datasets_info, model_txt=model_txt,system_info = get_system_info(),gpu_info = get_gpu_info(), chainer_version = get_chainer_version(), python_version = get_python_version())
 
 @app.route('/models/start/train', method="POST")
 def kick_train_start(db):
@@ -592,6 +592,7 @@ def get_gpu_info():
             xml = subprocess.check_output([NVIDIA_SMI_CMD, '-q', '-x'])
     except:
         return {'error': 'command_not_available'}
+		
     elem = fromstring(xml)
     ret['driver_version'] = elem.find('driver_version').text
     gpus = elem.findall('gpu')
@@ -618,6 +619,20 @@ def get_gpu_info():
         ret_gpus.sort(cmp=lambda x,y: cmp(int(x['minor_number']), int(y['minor_number'])))
     ret['gpus'] = ret_gpus
     return ret
+	
+def get_system_info():
+    df = subprocess.check_output(['df'])
+    disks=df[:-1].split('\n')
+    info=[]
+    info.append( disks[0].split() )
+    for i,disk in enumerate(disks):
+        row = disk.split()
+        print(row)
+        if row[0].find('/') > -1:
+           info.append(row)
+    print(info)
+    return info
+
 
 def get_chainer_version():
     return chainer.__version__

--- a/settings.yaml
+++ b/settings.yaml
@@ -6,18 +6,18 @@ debug: True
 # All paths must be absolute path.
 
 # Path for upload images.
-uploaded_images: /path/to/your/deepstation/uploaded_images
+uploaded_images: uploaded_images
 # Path for upload zip files.
-uploaded_raw_files: /path/to/your/deepstation/uploaded_raw_files
+uploaded_raw_files: uploaded_raw_files
 # Path for upload images to inspect.
-inspection_raw_image: /path/to/your/deepstation/inspection_raw_image
+inspection_raw_image: inspection_raw_image
 # Path to save temporary file for inspection
-inspection_temp_image: /path/to/your/deepstation/tmp_image
+inspection_temp_image: tmp_image
 
 # Path to save prepared data for training 
-prepared_data: /path/to/your/deepstation/prepared_data
+prepared_data: prepared_data
 # Path to save trained data
-trained_data: /path/to/your/deepstation/trained_data
+trained_data: trained_data
 
 # Path to nvidia-smi command
 nvidia_smi: nvidia-smi

--- a/views/base.html
+++ b/views/base.html
@@ -6,6 +6,14 @@
     <link rel="stylesheet" href="/statics/css/bootstrap.min.css">
     <link rel="stylesheet" href="/statics/CodeMirror/lib/codemirror.css">
     <link rel="stylesheet" href="/statics/css/deepstation.css">
+	<style>
+table{
+	width:100%
+}
+td{
+	text-aligh:right
+}
+	</style>
 </head>
 <body>
     {{!base}}

--- a/views/index.html
+++ b/views/index.html
@@ -88,6 +88,15 @@
                     </div>
                 % end
             </div>
+			<table width=100%>
+			% for row in system_info:
+			<tr>
+				% for col in row:
+				<td style="text-align:right">{{col}}</td>
+				% end
+			</tr>
+			% end
+			</table>
         </div>
         <div class="col-md-3">
             <table border="0">


### PR DESCRIPTION
`settings.yam` を記述する際に DEEPstationの`main.py`があるディレクトリからの相対パスをサポートするようにしました。

これは、学習結果を保存するディレクトリだけ別のストレージを指定したいというニーズがあるので、従来どおりの絶対パスでの記述をサポートしつつ、相対パスでもファイル保存先のディレクトリを指定することができるようになり、簡潔に設定ファイルを記述できるようになります。